### PR TITLE
Restrict our support to node10 and newer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
+dist: xenial
 language: node_js
 node_js:
-  - "6"
   - "10"
 script:
   - make

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "src/*",
     "internals/*",
     "*.gyp"
-  ]
+  ],
+  "engines": {
+    "node" : ">=10.0.0"
+  }
 }


### PR DESCRIPTION
Makes it easier to properly test, and internally our newer deployment
platforms will be node 10 and newer