### PR TITLE
Do not prevent the nodejs process from exiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator-nodejsmetrics",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1439,9 +1439,9 @@
       "dev": true
     },
     "nflx-spectator": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/nflx-spectator/-/nflx-spectator-0.0.1.tgz",
-      "integrity": "sha512-YeEHe8MFvjQeX7pI0o13UWLBqWVGQxFht5U/41121nuAn0V/eI/MZaj+0mrXkbnWShM5RGZfdhStypv4iEtbnw=="
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/nflx-spectator/-/nflx-spectator-0.0.2.tgz",
+      "integrity": "sha512-nRGTv5rSG7gWuQ6piRiREUgjE4KlaZiLvWGz+lIAjbJZxFJ7+8rbWUgidviXLBX9puPQT3XWjT1+KolJi99T4A=="
     },
     "node-pre-gyp": {
       "version": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator-nodejsmetrics",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Daniel Muino <dmuino@gmail.com>",
   "main": "src/index.js",
   "homepage": "https://github.org/Netflix/spectator-js",
@@ -11,8 +11,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bindings": "^1.3.1",
-    "nflx-spectator": "*",
-    "nan": "^2.11.1"
+    "nan": "^2.11.1",
+    "nflx-spectator": "^0.0.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -33,6 +33,6 @@
     "*.gyp"
   ],
   "engines": {
-    "node" : ">=10.0.0"
+    "node": ">=10.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,9 @@ class RuntimeMetrics {
 
   _fdActivity() {
     RuntimeMetrics.updateFdGauges(this, r.GetCurMaxFd);
-    this._intervals.push(setInterval(RuntimeMetrics.updateFdGauges, 10000, this, r.GetCurMaxFd));
+    const reg = this.registry;
+    this._intervals.push(reg.schedulePeriodically(
+      RuntimeMetrics.updateFdGauges, 10000, this, r.GetCurMaxFd));
   }
 
   static updateEvtLoopLag(self) {
@@ -186,7 +188,9 @@ class RuntimeMetrics {
   _evtLoopLag() {
     const now = this.registry.hrtime();
     this._lastNanos = now[0] * 1e9 + now[1];
-    this._intervals.push(setInterval(RuntimeMetrics.updateEvtLoopLag, 1000, this));
+    const reg = this.registry;
+    this._intervals.push(reg.schedulePeriodically(
+      RuntimeMetrics.updateEvtLoopLag, 1000, this));
   }
 
   static measureEvtLoopTime(self) {
@@ -199,7 +203,9 @@ class RuntimeMetrics {
   }
 
   _evtLoopTime() {
-    this._intervals.push(setInterval(RuntimeMetrics.measureEvtLoopTime, 500, this));
+    const reg = this.registry;
+    this._intervals.push(reg.schedulePeriodically(
+      RuntimeMetrics.measureEvtLoopTime, 500, this));
     RuntimeMetrics.measureEvtLoopTime(this);
   }
 
@@ -231,7 +237,8 @@ class RuntimeMetrics {
 
   _cpuHeap() {
     RuntimeMetrics.measureCpuHeap(this);
-    this._intervals.push(setInterval(RuntimeMetrics.measureCpuHeap, 10000, this));
+    const reg = this.registry;
+    this._intervals.push(reg.schedulePeriodically(RuntimeMetrics.measureCpuHeap, 10000, this));
   }
 
   start() {

--- a/test/nodemetrics.test.js
+++ b/test/nodemetrics.test.js
@@ -6,6 +6,14 @@ const NodeMetrics = require('../');
 const assert = require('chai').assert;
 
 describe('nodemetrics', () => {
+  it('should not prevent node from exiting', () => {
+    // basic test to make sure `start()` with no `stop()`
+    // does not prevent the mocha from exiting
+    const registry = new spectator.Registry({strictMode: true, gaugePollingFrequency: 1});
+    const metrics = new NodeMetrics(registry);
+    metrics.start();
+  });
+
   it('should generate a few meters', (done) => {
     // basic test to make sure `start()` actually starts the
     // collection


### PR DESCRIPTION
This switches the calls to `setInterval` to
`registry.schedulePeriodically` that won't prevent the nodejs
process from exiting in case `stop` is never called