### PR TITLE
Support node12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 language: node_js
 node_js:
   - "10"
+  - "12"
 script:
   - make
 after_success:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator-nodejsmetrics",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -80,22 +80,6 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
-      "dev": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/argparse/-/argparse-1.0.10.tgz",
@@ -140,9 +124,12 @@
       "dev": true
     },
     "bindings": {
-      "version": "1.3.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/bindings/-/bindings-1.3.1.tgz",
-      "integrity": "sha1-Ifx8bWfBhRbsWqooFbFF/3eybqU="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -204,12 +191,6 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
-    },
-    "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ=",
-      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -293,12 +274,6 @@
         "typedarray": "^0.0.6"
       }
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
-    },
     "core-js": {
       "version": "2.6.0",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/core-js/-/core-js-2.6.0.tgz",
@@ -369,28 +344,10 @@
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
-      "dev": true
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true
     },
     "diff": {
@@ -712,6 +669,11 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "flat-cache": {
       "version": "1.3.4",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/flat-cache/-/flat-cache-1.3.4.tgz",
@@ -724,36 +686,11 @@
         "write": "^0.2.1"
       }
     },
-    "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha1-BsJ3IYRU7CiN93raVKA7hwKqy50=",
-      "dev": true,
-      "requires": {
-        "minipass": "^2.2.1"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
     },
     "generate-function": {
       "version": "2.3.1",
@@ -861,12 +798,6 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/he/-/he-1.1.1.tgz",
@@ -922,7 +853,6 @@
       "version": "0.4.24",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -932,15 +862,6 @@
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ignore/-/ignore-3.3.10.tgz",
       "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
       "dev": true
-    },
-    "ignore-walk": {
-      "version": "3.0.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha1-qD5i59JyrA47VRqqgoMaGbafgvg=",
-      "dev": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -968,12 +889,6 @@
       "version": "2.0.3",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
       "dev": true
     },
     "inquirer": {
@@ -1299,25 +1214,6 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
-    "minipass": {
-      "version": "2.3.5",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha1-ys6+SSAiSX9law8PUeJoKp7S2Eg=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "1.2.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha1-3SfqYTYkPHyIBoToZyuzpF/ZthQ=",
-      "dev": true,
-      "requires": {
-        "minipass": "^2.2.1"
-      }
-    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -1405,9 +1301,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha1-kOIrzLjKV+pM03zIPTgZtS7qZ2Y="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "natural-compare": {
       "version": "1.2.2",
@@ -1421,17 +1317,6 @@
       "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
       "dev": true
     },
-    "needle": {
-      "version": "2.2.4",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/needle/-/needle-2.2.4.tgz",
-      "integrity": "sha1-UZMb/4JTOxkot9HWngHxsA/9Kk4=",
-      "dev": true,
-      "requires": {
-        "debug": "^2.1.2",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      }
-    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/next-tick/-/next-tick-1.0.0.tgz",
@@ -1439,36 +1324,40 @@
       "dev": true
     },
     "nflx-spectator": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/nflx-spectator/-/nflx-spectator-0.0.2.tgz",
-      "integrity": "sha512-nRGTv5rSG7gWuQ6piRiREUgjE4KlaZiLvWGz+lIAjbJZxFJ7+8rbWUgidviXLBX9puPQT3XWjT1+KolJi99T4A=="
-    },
-    "node-pre-gyp": {
-      "version": "0.12.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-      "integrity": "sha1-ObpLsUOdoDApX4meO1ILd4V2YUk=",
-      "dev": true,
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nflx-spectator/-/nflx-spectator-0.1.0.tgz",
+      "integrity": "sha512-PEpSNFXeMe0/e+AzDKTtp6+so3SqgY+qoP0GLcdvulwOcTk4hCh4xIXDqfq2fZ+1AlRuIe3EKmwn9UoJtc8/sQ==",
       "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4"
+        "async": "^3.1.0",
+        "needle": "^2.4.0"
       },
       "dependencies": {
-        "nopt": {
-          "version": "4.0.1",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-          "dev": true,
+        "async": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+          "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "needle": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+          "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+          "requires": {
+            "debug": "^3.2.6",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         }
       }
@@ -1515,34 +1404,6 @@
       "dev": true,
       "requires": {
         "abbrev": "1"
-      }
-    },
-    "npm-bundled": {
-      "version": "1.0.5",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/npm-bundled/-/npm-bundled-1.0.5.tgz",
-      "integrity": "sha1-PBcyt7qTazoQMlrvYWRnwMy8yXk=",
-      "dev": true
-    },
-    "npm-packlist": {
-      "version": "1.1.12",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/npm-packlist/-/npm-packlist-1.1.12.tgz",
-      "integrity": "sha1-Ir3i68EucspIKr1nr8UetJN3JDo=",
-      "dev": true,
-      "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1"
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -1610,22 +1471,6 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1685,32 +1530,6 @@
         "revalidator": "0.1.x",
         "utile": "0.2.x",
         "winston": "0.8.x"
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
-      "dev": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        }
       }
     },
     "read": {
@@ -1831,37 +1650,17 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
-      "dev": true
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
-      "dev": true
-    },
-    "semver": {
-      "version": "5.6.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha1-fnQlb7qknHWqfHogXMInmcrIAAQ=",
-      "dev": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "shelljs": {
       "version": "0.6.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "slice-ansi": {
@@ -2004,21 +1803,6 @@
             "ansi-regex": "^3.0.0"
           }
         }
-      }
-    },
-    "tar": {
-      "version": "4.4.8",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha1-sZ7sP94qluZGZt+f20DFyhvDdH0=",
-      "dev": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.4",
-        "minizlib": "^1.1.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
       }
     },
     "text-table": {
@@ -2171,15 +1955,6 @@
         "isexe": "^2.0.0"
       }
     },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
     "winston": {
       "version": "0.8.3",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/winston/-/winston-0.8.3.tgz",
@@ -2257,12 +2032,6 @@
       "version": "4.0.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha1-tLBJ4xS+VF486AIjbWzSLNkcPek=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator-nodejsmetrics",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "author": "Daniel Muino <dmuino@gmail.com>",
   "main": "src/index.js",
   "homepage": "https://github.org/Netflix/spectator-js",
@@ -10,17 +10,16 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "bindings": "^1.3.1",
-    "nan": "^2.11.1",
-    "nflx-spectator": "^0.0.2"
+    "bindings": "^1.5.0",
+    "nan": "^2.14.0",
+    "nflx-spectator": "^0.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^2.13.1",
     "istanbul": "^0.4.5",
     "jscs": "^3.0.7",
-    "mocha": "^5.2.0",
-    "node-pre-gyp": "0.12.0"
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "test": "mocha --reporter spec",


### PR DESCRIPTION
Upgrade nan and use some of its functions instead of making v8 calls
directly to be able to support multiple node versions more cleanly.

Fixes #10 