### PR TITLE
Update CPU and Heap metrics every 60s

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -173,7 +173,7 @@ class RuntimeMetrics {
     RuntimeMetrics.updateFdGauges(this, r.GetCurMaxFd);
     const reg = this.registry;
     this._intervals.push(reg.schedulePeriodically(
-      RuntimeMetrics.updateFdGauges, 10000, this, r.GetCurMaxFd));
+      RuntimeMetrics.updateFdGauges, 60000, this, r.GetCurMaxFd));
   }
 
   static updateEvtLoopLag(self) {
@@ -239,7 +239,7 @@ class RuntimeMetrics {
   _cpuHeap() {
     RuntimeMetrics.measureCpuHeap(this);
     const reg = this.registry;
-    this._intervals.push(reg.schedulePeriodically(RuntimeMetrics.measureCpuHeap, 10000, this));
+    this._intervals.push(reg.schedulePeriodically(RuntimeMetrics.measureCpuHeap, 60000, this));
   }
 
   start() {


### PR DESCRIPTION
Instead of 10s to match the behavior of the old atlas-node-client