### PR TITLE
Add EventLoopUtilization gauges

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'spectator_internals',
       'dependencies': [],
-      'sources': ["<!@(ls -1 internals/*.cc)"],
+      'sources': ["internals/functions.cc"],
       'include_dirs' : [
         "<!(node -e \"require('nan')\")"
       ],


### PR DESCRIPTION
Adds two gauges:

`nodejs.eventLoop id:idle` and `nodejs.eventLoop id:active` that track
the percentage of time the event loop has been active or idle. While
this is similar to the CPU utilization metrics it differs when there are
blocking calls in the event loop that might not be consuming CPU cycles.
(For example a synchronous I/O call, or spawning and waiting for an
external process).

For details see https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_eventlooputilization_utilization1_utilization2

Fixes #19