### PR TITLE
Fix conflict in name for ELU + add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ a timer once per second.
 
 **Unit:** seconds
 
+### nodejs.eventLoopUtilization
+
+Percentage of time the event loop has been idle or active. If the active value
+approaches 100% but the CPU utilization is low it indicates there are calls
+that are blocking the event loop.
+
+**Unit:** percent
+
+**Dimensions:**
+
+* `id`: `idle`, `active`
+
 ## Garbage Collection Metrics
 
 ### nodejs.gc.allocationRate

--- a/src/index.js
+++ b/src/index.js
@@ -83,9 +83,9 @@ class RuntimeMetrics {
     });
     this.lastCpuUsage = process.cpuUsage();
     this.lastCpuUsageTime = registry.hrtime();
-    this.eventLoopIdle = registry.gauge('nodejs.eventLoop',
+    this.eventLoopIdle = registry.gauge('nodejs.eventLoopUtilization',
     { id: 'idle', 'nodejs.version': process.version });
-    this.eventLoopActive = registry.gauge('nodejs.eventLoop',
+    this.eventLoopActive = registry.gauge('nodejs.eventLoopUtilization',
     { id: 'active', 'nodejs.version': process.version });
   }
 


### PR DESCRIPTION
`nodejs.eventLoop` is already being used by a timer that measures how
long the event loop takes to complete

`nodejs.eventLoopUtilization` is the new metric being added that tracks
the percentage of time the event loop is active vs idle

Adds documentation about the new gauges