### PR TITLE
Only report active eventLoopUtilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,11 @@ a timer once per second.
 
 ### nodejs.eventLoopUtilization
 
-Percentage of time the event loop has been idle or active. If the active value
-approaches 100% but the CPU utilization is low it indicates there are calls
-that are blocking the event loop.
+Percentage of time the event loop has been active. If this value approaches
+100% but the CPU utilization is low it indicates there are calls that are
+blocking the event loop.
 
 **Unit:** percent
-
-**Dimensions:**
-
-* `id`: `idle`, `active`
 
 ## Garbage Collection Metrics
 

--- a/src/index.js
+++ b/src/index.js
@@ -83,10 +83,7 @@ class RuntimeMetrics {
     });
     this.lastCpuUsage = process.cpuUsage();
     this.lastCpuUsageTime = registry.hrtime();
-    this.eventLoopIdle = registry.gauge('nodejs.eventLoopUtilization',
-    { id: 'idle', 'nodejs.version': process.version });
-    this.eventLoopActive = registry.gauge('nodejs.eventLoopUtilization',
-    { id: 'active', 'nodejs.version': process.version });
+    this.eventLoopActive = registry.gauge('nodejs.eventLoopUtilization', extraTags);
   }
 
   _gcEvents(emitGcFunction) {
@@ -222,13 +219,8 @@ class RuntimeMetrics {
     const deltaNanos = nanos - lastNanos;
     const last = self.lastEventLoop;
     const current = self.eventLoopUtilization();
-    // compute idle percentage
-    const idle = current.idle * 1e6; // millis to nanos
     const active = current.active * 1e6;
-    const deltaIdle = idle - last.idle * 1e6;
     const deltaActive = active - last.active * 1e6;
-
-    self.eventLoopIdle.set(100.0 * deltaIdle / deltaNanos);
     self.eventLoopActive.set(100.0 * deltaActive / deltaNanos);
 
     self.lastEventLoopTime = now;

--- a/test/nodemetrics.test.js
+++ b/test/nodemetrics.test.js
@@ -216,9 +216,7 @@ describe('nodemetrics', () => {
     NodeMetrics.measureEvtLoopUtilization(metrics);
 
     const active = metrics.eventLoopActive;
-    const idle = metrics.eventLoopIdle;
     assert.closeTo(active.get(), 200 / 3.0, 1e-6);
-    assert.closeTo(idle.get(), 100 / 3.0, 1e-6);
 
     // 5s, 1s active, 4s idle
     seconds += 5;
@@ -227,7 +225,6 @@ describe('nodemetrics', () => {
     elu.utilization = 1 / 5.0;
     NodeMetrics.measureEvtLoopUtilization(metrics);
     assert.closeTo(active.get(), 100 / 5.0, 1e-6);
-    assert.closeTo(idle.get(), 400 / 5.0, 1e-6);
   });
 
   it('should provide a way to check whether it has started', () => {


### PR DESCRIPTION
This will make it easier to select the max value and make
it work when the `id` tag is not present in the query