### PR TITLE
feat: version bump to 2.0.1 to reflect the node-gyp c++17 changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator-nodejsmetrics",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Daniel Muino <dmuino@gmail.com>",
   "main": "src/index.js",
   "homepage": "https://github.org/Netflix/spectator-js",
@@ -12,7 +12,8 @@
   "dependencies": {
     "bindings": "^1.5.0",
     "nan": "^2.14.2",
-    "nflx-spectator": "^2.0.0"
+    "nflx-spectator": "^2.0.0",
+    "node-gyp": "^10.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
The changes in the commit 969efb4 are not published, so when this package is installed from npm, they are not reflected.