### PR TITLE
fix: wait 60 seconds before measuring nodejs.cpuUsage so that you don…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,6 @@ class RuntimeMetrics {
   }
 
   _cpuHeap() {
-    RuntimeMetrics.measureCpuHeap(this);
     const reg = this.registry;
     this._intervals.push(reg.schedulePeriodically(RuntimeMetrics.measureCpuHeap, 60000, this));
   }

--- a/test/nodemetrics.test.js
+++ b/test/nodemetrics.test.js
@@ -23,7 +23,7 @@ describe('nodemetrics', () => {
 
     setTimeout(() => {
       const meters = registry.meters();
-      assert.isTrue(meters.length > 40);
+      assert.isTrue(meters.length > 15);
       metrics.stop();
       done();
     });


### PR DESCRIPTION
…'t get an artificially high first reading