### PR TITLE
restore the original event loop lag time calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator-nodejsmetrics",
-  "version": "3.0.0-rc.2",
+  "version": "3.0.0-rc.3",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Netflix-Skunkworks/spectator-js-nodejsmetrics",
   "author": "Netflix Telemetry Engineering <netflix-atlas@googlegroups.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,7 +281,8 @@ export class RuntimeMetrics {
   static measureEventLoopLag(self: RuntimeMetrics): void {
     const now: [number, number] = process.hrtime();
     const nanos: number = now[0] * 1e9 + now[1];
-    const lag: number = nanos - self.lastNanos;
+    // subtract 1 second to account for the schedule period of 1 second
+    const lag: number = nanos - self.lastNanos - 1e9;
     if (lag > 0) {
       void self.eventLoopLagTimer.record([0, lag]);
     }

--- a/test/nodemetrics.test.ts
+++ b/test/nodemetrics.test.ts
@@ -157,7 +157,8 @@ describe("nodemetrics", (): void => {
     Object.defineProperty(process, "hrtime", {
       get(): () => [number, number] {
         return (): [number, number] => {
-          nanos += round * 1e6;  // 1ms lag first time, 2ms second time, etc.
+          // add 1 second to account for the schedule period of 1 second
+          nanos += 1e9 + round * 1e6;  // 1ms lag first time, 2ms second time, etc.
           ++round;
           return [0, nanos];
         };


### PR DESCRIPTION
The original version subtracts one second, to account for the schedule period.