### PR TITLE
fix(2.x): revert high-res CPU metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator-nodejsmetrics",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "Matthew Johnson <matthewj@netflix.com>",
   "main": "src/index.js",
   "homepage": "https://github.org/Netflix/spectator-js",

--- a/src/index.js
+++ b/src/index.js
@@ -279,7 +279,7 @@ class RuntimeMetrics {
 
   _cpuHeap() {
     const reg = this.registry;
-    this._intervals.push(reg.schedulePeriodically(RuntimeMetrics.measureCpuHeap, 10000, this));
+    this._intervals.push(reg.schedulePeriodically(RuntimeMetrics.measureCpuHeap, 60000, this));
   }
 
   start() {


### PR DESCRIPTION
High resolution CPU metrics were inflating the value of reported metrics and causing issues.