### PR TITLE
fix: use correct c++ version on OSX for Node.js 24+

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        node-version: ["18", "20", "22"]
+        node-version: ["18", "20", "22", "24"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        node-version: ["18", "20", "22"]
+        node-version: ["18", "20", "22", "24"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,6 +4,9 @@
     'conditions': [
         [ 'OS=="mac" and node_module_version >= 115', {
             'osx_cpp_version': "17"
+        }],
+        [ 'OS=="mac" and node_module_version >= 130', {
+            'osx_cpp_version': "20"
         }]
     ]
   },


### PR DESCRIPTION
Following logic from https://github.com/Netflix-Skunkworks/spectator-js-nodejsmetrics/pull/32

NodeJS LTS 24+ requires C++20